### PR TITLE
Add onBeforeRestore handler

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -202,17 +202,20 @@
 					if ( $.isFunction( self.options.onBeforeRestore ) ) {
 						var hasDataToRestore = false;
 						self.targets.each( function() {
-						var target = $( this );
-						var targetFormId = target.attr( "id" );
-						var fieldsToProtect = target.find( ":input" ).not( ":submit" ).not( ":reset" ).not( ":button" );
-						fieldsToProtect.each( function() {
-							var field = $( this );
-							var prefix = self.href + targetFormId + field.attr( "name" ) + self.options.customKeyPrefix;
-							var resque = localStorage.getItem( prefix );
-							if(resque) {
-								hasDataToRestore = true;
+							var target = $( this );
+							var targetFormId = target.attr( "id" );
+							var fieldsToProtect = target.find( ":input" ).not( ":submit" ).not( ":reset" ).not( ":button" );
+							fieldsToProtect.each( function() {
+								var field = $( this );
+								var prefix = self.href + targetFormId + field.attr( "name" ) + self.options.customKeyPrefix;
+								var resque = localStorage.getItem( prefix );
+								if(resque) {
+									hasDataToRestore = true;
+									return false;
+								}
+							});
+							if(hasDataToRestore)
 								return false;
-							}
 						});
 						if(hasDataToRestore)
 							continueRestore = self.options.onBeforeRestore.call();


### PR DESCRIPTION
Example usage:

jQuery('#mailing_edit').sisyphus(
 {  
     onBeforeRestore: function() { return confirm("Would you like to restore the data saved previously for this form?"); },
 });

It's only called if there is any data in localStorage to restore (thereby avoiding nagging the user unnecessarily)  
