### PR TITLE
Added "autoRelease" option and manual release method. Fixes Issue #12

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -42,6 +42,7 @@
 						excludeFields: null,
 						customKeyPrefix: "",
 						timeout: 0,
+						autoRelease: true,
 						onSave: function() {},
 						onRestore: function() {},
 						onRelease: function() {}
@@ -84,7 +85,9 @@
 					}
 				
 					self.restoreAllData();
-					self.bindReleaseData();
+					if ( this.options.autoRelease ) {
+						self.bindReleaseData();
+					}                                    
 					if ( ! params.started ) {
 						self.bindSaveData();
 						params.started = true;
@@ -345,6 +348,21 @@
 				
 				
 				},
+                                
+				/**
+				 * Manually release form fields
+				 *
+				 * @return void
+				 */
+				manuallyReleaseData: function() {
+					var self = this;
+					self.targets.each( function( i ) {
+						var target = $( this );
+						var fieldsToProtect = target.find( ":input" ).not( ":submit" ).not( ":reset" ).not( ":button" );
+						var formId = target.attr( "id" );
+						self.releaseData( formId, fieldsToProtect );
+					} )
+				},                                
 			
 			
 				/**


### PR DESCRIPTION
Here is an example use case with client side validation and ajax submitting data providing a "soft fail" if user has lost Internet connection (useful for e.g. mobile applications).

1) Validate form. Here using jquery.validation plugin
2) Ajax submit form.
3) Release local storage data if 1 & 2 successful.

Code example:

``` javascript
var sisyphus = $('form').sisyphus({autoRelease: false});

// Using jquery.validation plugin
$('form').validate({submitHandler: function(form)
{
  var jqxhr = $.post(window.location.href, $(form).serialize());

  jqxhr.success(function(data) 
  {
     // Successfully submitted data, release local storage
     sisyphus.manuallyReleaseData();
     console.log('Successfully submitted');
  });
  jqxhr.error(function(data)
  {
    // Failed to submit, keep local storage
     console.log('Failed to submit');
  });
}});
```
