### PR TITLE
Add OnBeforeRestore

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -111,6 +111,7 @@
 						autoRelease: true,
 						name: null,
 						onSave: function() {},
+						onBeforeRestore: function {},
 						onRestore: function() {},
 						onRelease: function() {}
 					};
@@ -257,7 +258,11 @@
 				restoreAllData: function() {
 					var self = this;
 					var restored = false;
-				
+					
+					if ( $.isFunction( self.options.onBeforeRestore ) ) {
+						self.options.onBeforeRestore.call();
+					}
+					
 					self.targets.each( function() {
 						var target = $( this );
 						var targetFormId = target.attr( "id" );


### PR DESCRIPTION
There is already pull request about it, but I think implementation is little wrong.

I add this request because, when you have dynamic generated forms (by ajax) you first must create this forms before launching restore function.
