### PR TITLE
Fix issue #20 for old jQuery version (< 1.6.2)

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -105,7 +105,7 @@
          */
         setInitialOptions: function ( options ) {
           var defaults = {
-            excludeFields: null,
+            excludeFields: [],
             customKeyPrefix: "",
             timeout: 0,
             autoRelease: true,


### PR DESCRIPTION
Instead of complaining to ask resolution when jQuery is < 1.6.2, I took a look into the error.

If we don't define some excludeFields when calling `sisyphus`, every time you made a `$.inArray` for checking excluded fields, you try to find `this` in a `null` variable:

``` javascript
if ( $.inArray( this, self.options.excludeFields ) !== -1 ) {
```

That's why it fails. Using `[]` as default instead of `null` fix the problem for old jQuery library.

Also, I fixed some indents, whitespace and removed all tabs (that's why it seems I modify all the file :-))
