### PR TITLE
Add input id to prefix

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -196,7 +196,7 @@
 								return true;
 							}
 							var field = $( this );
-							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr( "name" ) + self.options.customKeyPrefix;
+							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr("id") + field.attr( "name" ) + self.options.customKeyPrefix;
 							if ( field.is( ":text" ) || field.is( "textarea" ) ) {
 								if ( ! self.options.timeout ) {
 									self.bindSaveDataImmediately( field, prefix );
@@ -226,7 +226,7 @@
 								// Returning non-false is the same as a continue statement in a for loop; it will skip immediately to the next iteration.
 								return true;
 							}
-							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr( "name" ) + self.options.customKeyPrefix;
+							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr("id") + field.attr( "name" ) + self.options.customKeyPrefix;
 							var value = field.val();
 
 							if ( field.is(":checkbox") ) {
@@ -272,7 +272,7 @@
 								return true;
 							}
 							var field = $( this );
-							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr( "name" ) + self.options.customKeyPrefix;
+							var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr("id") + field.attr( "name" ) + self.options.customKeyPrefix;
 							var resque = self.browserStorage.get( prefix );
 							if ( resque ) {
 								self.restoreFieldsData( field, resque );
@@ -434,7 +434,7 @@
 							return true;
 						}
 						var field = $( this );
-						var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr( "name" ) + self.options.customKeyPrefix;
+						var prefix = (self.options.locationBased ? self.href : "") + targetFormIdAndName + field.attr("id") + field.attr( "name" ) + self.options.customKeyPrefix;
 						self.browserStorage.remove( prefix );
 						released = true;
 					} );
@@ -467,3 +467,4 @@
 		};
 	} )();
 } )( jQuery );
+


### PR DESCRIPTION
This allows us to handle forms which have two inputs of the same name.

In Rails, if you do a multiselect form element, it adds a hidden input with an empty value, to make sure that you always submit something back to the server, such that you can select the empty set. This hidden input has the same name as the select, but is distinguishable by id, so we want to also use that to store and restore values.
