### PR TITLE
Added MIT License to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Smashing Magazine article: http://coding.smashingmagazine.com/2011/12/05/sisyphu
 5. Send a pull request
 
 Author: Alexander Kaupanin
+
+# LICENSE
+
+MIT License.


### PR DESCRIPTION
Could you append `MIT license` declaration to README.md? because, written as **MIT License** by [this production official site](http://sisyphus-js.herokuapp.com/).
