### PR TITLE
Add a timeout to the onChange event

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -417,7 +417,7 @@
 				bindSaveDataOnChange: function( field ) {
 					var self = this;
 					field.change( function() {
-						self.saveAllData();
+						setTimeout(function () { self.saveAllData(); }, 0);
 					} );
 				},
 


### PR DESCRIPTION
Having the onChange event trigger saving every field on a form can cause the browser UI to respond slowly when there are a large number of fields. Wrapping the save event into a timeout will save the changes asynchrony, allowing the user to continue using the form while changes are saved in the background


