### PR TITLE
Use of .prop() instead of .attr() for setting radio button checked.

### DIFF
--- a/sisyphus.js
+++ b/sisyphus.js
@@ -349,7 +349,7 @@
 						field.removeAttr( "checked" );
 					} else if ( field.is( ":radio" ) ) {
 						if ( field.val() === resque ) {
-							field.attr( "checked", "checked" );
+							field.prop( "checked", true );
 						}
 					} else if ( field.attr( "name" ).indexOf( "[" ) === -1 ) {
 						field.val( resque );


### PR DESCRIPTION
On older browsers, radio buttons were not set.
See http://stackoverflow.com/questions/6432246/radio-buttons-and-attrchecked-checked-does-not-work-in-ie7