### PR TITLE
Added id to field identifier key

### DIFF
--- a/spec/spec.js
+++ b/spec/spec.js
@@ -185,7 +185,7 @@ describe("jQuery.sisyphus", function() {
 
 	it( "should return a Sisyphus instance", function() {
 		var form = $( "#form1");
-		var identifier = form.attr( "id" ) + form.attr( "name" );
+		var identifier = '[id=' + form.attr( "id" ) + '][name=' + form.attr( "name" ) + ']';
 		var o =  $( "#form1" ).sisyphus(),
 				sisyphus = Sisyphus.getInstance( identifier );
 		expect( o ).toEqual( sisyphus );
@@ -200,7 +200,7 @@ describe("jQuery.sisyphus", function() {
 
 	it( "should protect matched forms with Sisyphus", function() {
 		var form = $( "#form1");
-		var identifier = form.attr( "id" ) + form.attr( "name" );
+		var identifier = '[id=' + form.attr( "id" ) + '][name=' + form.attr( "name" ) + ']';
 		spyOn( Sisyphus.getInstance( identifier ), "protect" );
 		$( "#form1" ).sisyphus(),
 		expect( Sisyphus.getInstance( identifier ).protect ).toHaveBeenCalled();


### PR DESCRIPTION
As discussed in #121, we (@underdogio) has a use case that requires `id` support for fields that aren't being sent to the server. In order to address this, we have added `id` support to all field identifiers as well as a delimiter to prevent potential crossover.

In this PR:

- Added common `getElementIdentifier` resolver
- Updated all `id`/`name` resolvers to use `getElementIdentifier`
- Updated multiple `name` logic (e.g. `checkboxes[]`) to support `name` not existing
- Updated tests